### PR TITLE
(maint) Acceptance test rake task and travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,30 @@
+sudo: false
 language: ruby
-script:
-  - bundle exec rake lint spec
+cache: bundler
+before_install:
+  - gem update bundler
 notifications:
   email: false
-rvm:
-  - 2.1.6
-  - 2.3.0
+matrix:
+  fast_finish: true
+  include:
+  - rvm: 2.1.6
+    dist: trusty
+    env: RAKE_VER=10.0
+    script: bundle exec rake lint spec
+  - rvm: 2.3.0
+    dist: trusty
+    env: RAKE_VER=10.0
+    script: bundle exec rake lint spec
+  - rvm: 2.3.0
+    dist: trusty
+    env: RAKE_VER=10.0 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
+    script: bundle exec rake acceptance
+    services: docker
+    sudo: required
+  - rvm: 2.3.0
+    dist: trusty
+    env: RAKE_VER=10.0 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
+    script: bundle exec rake acceptance
+    services: docker
+    sudo: required

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem 'bundler', '~> 1.9'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3'
+  gem 'rototiller', git: 'https://github.com/puppetlabs/rototiller.git', tag: '1.0.0'
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 require 'bundler/gem_tasks'
+require 'fileutils'
+require 'rototiller'
+require 'rubocop/rake_task'
+
 task default: [:lint, :spec]
 
-require 'rubocop/rake_task'
 desc 'Run rubocop'
 RuboCop::RakeTask.new(:lint) do |t|
   t.requires << 'rubocop-rspec'
@@ -12,4 +15,38 @@ desc 'Run spec tests using rspec'
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = ['--color']
   t.pattern = 'spec'
+end
+
+desc 'Run acceptance tests of a puppet module'
+rototiller_task :acceptance do |t|
+  t.add_env(name: 'ACCEPTANCE_CMD',
+            message: 'Command to use to run the acceptance tests of the module',
+            default: 'bundle exec rspec spec/acceptance')
+
+  t.add_env(name: 'ACCEPTANCE_GIT_REPO',
+            message: 'Git repo of the module to test',
+            default: 'https://github.com/puppetlabs/puppetlabs-ntp.git')
+
+  t.add_env(name: 'ACCEPTANCE_GIT_REPO_FOLDER',
+            message: 'Root folder within which to clone the module.',
+            default: 'ntp')
+
+  t.add_env(name: 'ACCEPTANCE_GIT_REF',
+            message: 'Git repo reference of the module to test. Can be branch, commit sha or tag.',
+            default: 'master')
+
+  t.add_command do |c|
+    # Create repo root folder
+    c.name = <<-SCRIPT
+mkdir -p spec/acceptance/.tmp &&
+rm -rf spec/acceptance/.tmp/${ACCEPTANCE_GIT_REPO_FOLDER} &&
+git clone ${ACCEPTANCE_GIT_REPO} spec/acceptance/.tmp/${ACCEPTANCE_GIT_REPO_FOLDER} &&
+cd spec/acceptance/.tmp/${ACCEPTANCE_GIT_REPO_FOLDER} &&
+git checkout ${ACCEPTANCE_GIT_REF} &&
+cat Gemfile | sed -e "s/gem \'beaker-module_install_helper\', /gem \'beaker-module_install_helper\', :path => \'#{Shellwords.escape(File.dirname(__FILE__)).gsub('/', '\/')}\', /" > GemfileModified &&
+echo 'Edited Gemfile: ' && cat GemfileModified &&
+bundle install --gemfile=./GemfileModified --path=./.bundle/gems &&
+${ACCEPTANCE_CMD}
+    SCRIPT
+  end
 end


### PR DESCRIPTION
This is a rake task which is implemented using rototiller which allows an external modules acceptance tests to be ran using the local beaker-module_install_helper source code. This is done by cloning the module using git and then doing a regex replace using the bash `sed` command on the Gemfile to replace the beaker-module_install_helper dependency with the local source code for beaker-module_install_helper.

The module to use to test against can be changed using environment variables, as can the command used to run the acceptance tests. Any other required environment variables such as PUPPET_INSTALL_TYPE etc can be set as normal.

These changes also include updates to the travis config so the NTP acceptance tests run on travis on every PR and rototiller has been included in the Gemfile. The rototiller 1.0.0 tag from the git repo was required and is not yet released to rubygems that is why the git repo is referenced in the Gemfile.