### PR TITLE
Don't attempt to modify possibly frozen strings

### DIFF
--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -52,10 +52,10 @@ module Beaker::ModuleInstallHelper
   end
 
   def install_module_from_forge_on(hsts, mod_name, ver_req)
-    mod_name.sub!('/', '-')
+    sub_mod_name = mod_name.sub('/', '-')
     dependency = {
-      module_name: mod_name,
-      version: module_version_from_requirement(mod_name, ver_req)
+      module_name: sub_mod_name,
+      version: module_version_from_requirement(sub_mod_name, ver_req)
     }
 
     install_module_dependencies_on(hsts, [dependency])


### PR DESCRIPTION
Ruby 2.3 introduces frozen string literals. Performing a sub! on a string may result in an exception being thrown if the string originally comes from a literal. This PR fixes that problem. 