### PR TITLE
add basic Net::HTTP error handling

### DIFF
--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -92,8 +92,10 @@ module Beaker::ModuleInstallHelper
   def module_version_from_requirement(mod_name, vr_str)
     require 'net/http'
     uri = URI("#{forge_api}v3/modules/#{mod_name}")
-    response = Net::HTTP.get(uri)
-    forge_data = JSON.parse(response)
+    response = Net::HTTP.get_response(uri)
+    raise "Puppetforge API error '#{uri}': '#{response.body}'" if response.code.to_i >= 400
+
+    forge_data = JSON.parse(response.body)
 
     vrs = version_requirements_from_string(vr_str)
 

--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -103,7 +103,7 @@ module Beaker::ModuleInstallHelper
       return rel['version'] if vrs.all? { |vr| vr.match?('', rel['version']) }
     end
 
-    raise "No release version found matching '#{vr_str}'"
+    raise "No release version found matching '#{mod_name}' '#{vr_str}'"
   end
 
   # This method takes a version requirement string as specified in the link

--- a/spec/unit/beaker/module_install_helper_spec.rb
+++ b/spec/unit/beaker/module_install_helper_spec.rb
@@ -358,4 +358,14 @@ describe Beaker::ModuleInstallHelper do
       install_module_from_forge_on(a_host, input_module_name, input_module_version_requirement)
     end
   end
+
+  describe 'module_version_from_requirement' do
+    context 'when looking up *unresolvable* version contraints for a valid module' do
+      it 'gets a response', live_fire: true do
+        expect do
+          module_version_from_requirement('puppetlabs-vcsrepo', '> 1.4 < 1.5')
+        end.to raise_error(/^No release version found matching 'puppetlabs-vcsrepo' '> 1.4 < 1.5'/)
+      end
+    end
+  end
 end

--- a/spec/unit/beaker/module_install_helper_spec.rb
+++ b/spec/unit/beaker/module_install_helper_spec.rb
@@ -360,11 +360,26 @@ describe Beaker::ModuleInstallHelper do
   end
 
   describe 'module_version_from_requirement' do
+    context 'when looking up resolvable version contraints for a valid module' do
+      it 'gets a response', live_fire: true do
+        ver = module_version_from_requirement('puppetlabs-vcsrepo', '>= 1 < 2')
+        expect(ver).to eq '1.5.0'
+      end
+    end
+
     context 'when looking up *unresolvable* version contraints for a valid module' do
       it 'gets a response', live_fire: true do
         expect do
           module_version_from_requirement('puppetlabs-vcsrepo', '> 1.4 < 1.5')
         end.to raise_error(/^No release version found matching 'puppetlabs-vcsrepo' '> 1.4 < 1.5'/)
+      end
+    end
+
+    context 'when looking up metadata for a *invalid* module name' do
+      it 'gets a response', live_fire: true do
+        expect do
+          module_version_from_requirement('puppet-does-not-exist', '>= 1 < 2')
+        end.to raise_error(/^Puppetforge API error/)
       end
     end
   end


### PR DESCRIPTION
Note that two of the new unit tests are calling the live puppetforge API.  This may be excluded with the rspec `live_fire` tag. E.g. ` rspec --tag ~live_fire`